### PR TITLE
fix for latest version of numpy

### DIFF
--- a/screen.py
+++ b/screen.py
@@ -20,8 +20,8 @@ class Screen:
         y, x = obj.get_position()
         h, w = obj.get_dimensions()
 
-        x = round(np.asscalar(x))
-        y = round(np.asscalar(y))
+        x = round(x.item())
+        y = round(y.item())
 
         display, color = obj.get_representation(frame)
 


### PR DESCRIPTION
latest version of numpy does not support numpy.asscalar() method.
fixed by changing to array.item() method on line 23,24 in screen.py